### PR TITLE
fixed some method call without argument values

### DIFF
--- a/src/Bittrex.php
+++ b/src/Bittrex.php
@@ -159,7 +159,11 @@ class Bittrex
      */
     public function getOrderHistory($market = '')
     {
-        return $this->authRequest('account/getorderhistory', "market={$market}");
+        if ($market) {
+            return $this->authRequest('account/getorderhistory', "market={$market}");
+        } else {
+            return $this->authRequest('account/getorderhistory');
+        }
     }
 
     /**
@@ -169,7 +173,11 @@ class Bittrex
      */
     public function getWithdrawalHistory($currency = '')
     {
-        return $this->authRequest('account/getwithdrawalhistory', "currency={$currency}");
+        if ($currency) {
+            return $this->authRequest('account/getwithdrawalhistory', "currency={$currency}");
+        } else {
+            return $this->authRequest('account/getwithdrawalhistory');
+        }
     }
 
     /**
@@ -179,7 +187,11 @@ class Bittrex
      */
     public function getDepositHistory($currency = '')
     {
-        return $this->authRequest('account/getdeposithistory', "currency={$currency}");
+        if ($currency) {
+            return $this->authRequest('account/getdeposithistory', "currency={$currency}");
+        } else {
+            return $this->authRequest('account/getdeposithistory');
+        }
     }
 
     /**


### PR DESCRIPTION
call "getOrderHistory", getWithdrawalHistory or getWithdrawalHistory with no arguments, it failed with "INVALID_CURRENCY" error.